### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Pre-commit hooks. For more information see https://github.com/pre-commit/pre-commit-hooks/blob/main/README.md
 
 - id: capitalize-comments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 [build-system]
 requires = ["setuptools", "wheel"]


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced license formatting for improved clarity and consistency across the repo.  

### 📊 Key Changes  
- Updated license headers in several files to a clearer and more standardized format.  
  - Changed "Ultralytics YOLO 🚀, AGPL-3.0 license" to "Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license".  
- Updated comments in `format.yml`, `.pre-commit-hooks.yaml`, and `pyproject.toml` files for consistency.  

### 🎯 Purpose & Impact  
- 🧹 **Improved consistency**: Ensures that the license header is consistent across all files, making it easier to reference and understand.  
- 📜 **Clarity**: Directs users to the license link for more detailed information.  
- 🛠️ **Minimal impact on functionality**: No functional changes; this is purely an improvement in documentation and formatting for readability.