### PR TITLE
Fix unused comment flag

### DIFF
--- a/capitalize_comments.py
+++ b/capitalize_comments.py
@@ -16,7 +16,9 @@ def capitalize_comment_line(line: str, prev_was_comment: bool) -> str:
     if prev_was_comment:
         return line
 
-    return re.sub(r"^(\s*)# (\w)", lambda m: f"{m.group(1)}# {m.group(2).upper()}", line)
+    return re.sub(
+        r"^(\s*)# (\w)", lambda m: f"{m.group(1)}# {m.group(2).upper()}", line
+    )
 
 
 def process_file(file_path: Path):
@@ -27,7 +29,7 @@ def process_file(file_path: Path):
     prev_was_comment = False
     processed_lines = []
     for line in lines:
-        if is_comment := line.strip().startswith("#"):
+        if line.strip().startswith("#"):
             processed_line = capitalize_comment_line(line, prev_was_comment)
             processed_lines.append(processed_line)
             prev_was_comment = True

--- a/capitalize_comments.py
+++ b/capitalize_comments.py
@@ -16,9 +16,7 @@ def capitalize_comment_line(line: str, prev_was_comment: bool) -> str:
     if prev_was_comment:
         return line
 
-    return re.sub(
-        r"^(\s*)# (\w)", lambda m: f"{m.group(1)}# {m.group(2).upper()}", line
-    )
+    return re.sub(r"^(\s*)# (\w)", lambda m: f"{m.group(1)}# {m.group(2).upper()}", line)
 
 
 def process_file(file_path: Path):


### PR DESCRIPTION
## Summary
- remove the unused walrus assignment in the comment capitalization hook
- run Ruff formatting on the touched file

## Tests
- ruff check --select F841 capitalize_comments.py
- ruff check capitalize_comments.py
- ruff format capitalize_comments.py
- python -m py_compile capitalize_comments.py
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR makes a small cleanup in `capitalize_comments.py` by removing an unused inline variable assignment while keeping behavior unchanged.

### 📊 Key Changes
- Removed the walrus operator assignment in the comment check:
  - Changed `if is_comment := line.strip().startswith("#"):` to `if line.strip().startswith("#"):`
- Kept the script’s logic exactly the same:
  - Comment lines are still detected and processed as before.
  - `prev_was_comment` behavior is unchanged.

### 🎯 Purpose & Impact
- Improves code clarity ✨ by removing an unnecessary variable that was not used elsewhere.
- Makes the implementation a bit easier to read and maintain for contributors.
- Reduces minor linting or style concerns 🛠️ without affecting functionality.
- No expected user-facing impact 📌; this is a safe internal refactor/cleanup.